### PR TITLE
make sorting deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # `toposort`: a topological sorting library
 
-This package implements a basic topological sorting library using Khan's algorithm.
+This package implements a basic topological sorting library using Khan's algorithm. Sorts from this library should be deterministic.
 
 ## Topological Sorting
 
 > In computer science, a topological sort or topological ordering of a directed graph is a linear ordering of its vertices such that for every directed edge uv from vertex u to vertex v, u comes before v in the ordering. &mdash;[Wikipedia](https://en.wikipedia.org/wiki/Topological_sorting)
 
 ![Image of graph and its topological sorting](https://raw.githubusercontent.com/oko/toposort/master/example/bigger.topo.png)
+
+Sorts generated should be deterministic, i.e. if you run the sort many times the output will be the same for all sorts.
 
 ## Example
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/oko/toposort
 go 1.13
 
 require (
+	github.com/emirpasic/gods v1.12.0
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/jessevdk/go-flags v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
+github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=

--- a/scripts/example.sh
+++ b/scripts/example.sh
@@ -2,5 +2,6 @@
 set -eux
 ex="$1"
 out=/tmp/"$(basename "$ex")".png
+out="${2:-"$out"}"
 go run ./bin --topo "$ex" | /usr/bin/dot /dev/stdin -Tpng -o "$out"
 xdg-open "$out"


### PR DESCRIPTION
Adds use of a binary heap during node and edge processing to make
the sort order deterministic. Node heap ensures that we start from
the same node for a given graph, and edge heap ensures that from a
given node N we traverse edges from N -> {X, Y, Z} in order of
`Id()` value.